### PR TITLE
Add touch/mouse props to optionally disable specific events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+export interface GestureState {
+    x: number;
+    y: number;
+    xDelta: number;
+    yDelta: number;
+    xInitial: number;
+    yInitial: number;
+    xPrev: number;
+    yPrev: number;
+    down: boolean;
+
+    xVelocity: number;
+    yVelocity: number;
+}
+
+type GestureChildComponent<T> = React.ComponentType<T & GestureState>;
+
+export interface WithGestureProps {
+    onUp?: (newProps: GestureState) => GestureState;
+    onDown?: (newProps: GestureState) => GestureState;
+    onMove?: (newProps: GestureState) => GestureState;
+}
+
+export interface GestureProps {
+    children(props: GestureState): React.ReactNode;
+}
+
+export function withGesture<T>(
+    WrappedComponent: GestureChildComponent<T>,
+): React.ComponentType<T & WithGestureProps>;
+
+export class Gesture extends React.Component<GestureProps & WithGestureProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,9 @@ export interface WithGestureProps {
     onUp?: (newProps: GestureState) => GestureState;
     onDown?: (newProps: GestureState) => GestureState;
     onMove?: (newProps: GestureState) => GestureState;
+
+    touch?: boolean;
+    mouse?: boolean;
 }
 
 export interface GestureProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface GestureState {
     yVelocity: number;
 }
 
-type GestureChildComponent<T> = React.ComponentType<T & GestureState>;
+type GestureChildComponent<T> = React.ComponentType<T & Partial<GestureState>>;
 
 export interface WithGestureProps {
     onUp?: (newProps: GestureState) => GestureState;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "scripts": {
         "prebuild": "rimraf dist",
         "build": "rollup -c",
-        "prepare": "npm run build"
+        "prepare": "npm run build",
+        "test:typings": "typings-tester --dir test/typescript"
     },
     "repository": {
         "type": "git",
@@ -44,7 +45,9 @@
         "react-dom": "16.2.0",
         "rimraf": "2.6.2",
         "rollup": "0.56.2",
-        "rollup-plugin-babel": "4.0.0-beta.2"
+        "rollup-plugin-babel": "4.0.0-beta.2",
+        "typescript": "^3.0.1",
+        "typings-tester": "^0.3.1"
     },
     "peerDependencies": {
         "prop-types": "15.x.x",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "hoc for receiving gestures",
     "main": "dist/react-with-gesture",
     "module": "dist/react-with-gesture.es",
+    "typings": "./index.d.ts",
     "sideEffects": false,
     "scripts": {
         "prebuild": "rimraf dist",
@@ -34,6 +35,7 @@
         "@babel/preset-react": "7.0.0-beta.40",
         "@babel/preset-stage-2": "7.0.0-beta.40",
         "@babel/runtime": "7.0.0-beta.40",
+        "@types/react": "^16.4.9",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "22.4.0",
         "babel-plugin-annotate-pure-calls": "0.3.0-beta.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,17 @@ import React from 'react'
 
 const withGesture = Wrapped =>
     class extends React.Component {
-        state = { x: 0, y: 0, xDelta: 0, yDelta: 0, xInitial: 0, yInitial: 0, xPrev: 0, yPrev: 0, down: false }
+        state = {
+            x: 0,
+            y: 0,
+            xDelta: 0,
+            yDelta: 0,
+            xInitial: 0,
+            yInitial: 0,
+            xPrev: 0,
+            yPrev: 0,
+            down: false
+        }
 
         handleTouchStart = e => this.handleMouseDown(e.touches[0])
         handleTouchMove = e => this.handleMouseMove(e.touches[0])
@@ -12,8 +22,13 @@ const withGesture = Wrapped =>
             window.removeEventListener('touchend', this.handleMouseUp)
             window.removeEventListener('mousemove', this.handleMouseMoveRaf)
             window.removeEventListener('mouseup', this.handleMouseUp)
-            const newProps = { ...this.state, down: false }
-            this.setState(this.props.onUp ? this.props.onUp(newProps) : newProps)
+            const newProps = {
+                ...this.state,
+                down: false
+            }
+            this.setState(
+                this.props.onUp ? this.props.onUp(newProps) : newProps
+            )
         }
 
         handleMouseDown = ({ pageX, pageY }) => {
@@ -21,17 +36,49 @@ const withGesture = Wrapped =>
             window.addEventListener('touchend', this.handleMouseUp)
             window.addEventListener('mousemove', this.handleMouseMoveRaf)
             window.addEventListener('mouseup', this.handleMouseUp)
-            const newProps = { ...this.state, x: pageX, y: pageY, xDelta: 0, yDelta: 0, xInitial: pageX, yInitial: pageY, xPrev: pageX, yPrev: pageY, down: true }
-            this.setState(this.props.onDown ? this.props.onDown(newProps) : newProps)
+            const newProps = {
+                ...this.state,
+                x: pageX,
+                y: pageY,
+                xDelta: 0,
+                yDelta: 0,
+                xInitial: pageX,
+                yInitial: pageY,
+                xPrev: pageX,
+                yPrev: pageY,
+                down: true
+            }
+            this.setState(
+                this.props.onDown ? this.props.onDown(newProps) : newProps
+            )
         }
 
         handleMouseMoveRaf = ({ pageX, pageY }) => {
-            !this._busy && requestAnimationFrame(() => this.handleMouseMove({ pageX, pageY }))
+            !this._busy &&
+            requestAnimationFrame(() =>
+                this.handleMouseMove({
+                    pageX,
+                    pageY
+                })
+            )
             this._busy = true
         }
         handleMouseMove = ({ pageX, pageY }) => {
-            const newProps = { ...this.state, x: pageX, y: pageY, xDelta: pageX - this.state.xInitial, yDelta: pageY - this.state.yInitial, xPrev: this.state.x, yPrev: this.state.y, xVelocity: pageX - this.state.x, yVelocity: pageY - this.state.y }
-            this.setState(this.props.onMove ? this.props.onMove(newProps) : newProps, () => (this._busy = false))
+            const newProps = {
+                ...this.state,
+                x: pageX,
+                y: pageY,
+                xDelta: pageX - this.state.xInitial,
+                yDelta: pageY - this.state.yInitial,
+                xPrev: this.state.x,
+                yPrev: this.state.y,
+                xVelocity: pageX - this.state.x,
+                yVelocity: pageY - this.state.y
+            }
+            this.setState(
+                this.props.onMove ? this.props.onMove(newProps) : newProps,
+                () => (this._busy = false)
+            )
         }
 
         render() {
@@ -41,7 +88,8 @@ const withGesture = Wrapped =>
                     onMouseDown={this.handleMouseDown}
                     onTouchStart={this.handleTouchStart}
                     style={{ display: 'contents', ...style }}
-                    className={className}>
+                    className={className}
+                >
                     <Wrapped {...props} {...this.state} />
                 </div>
             )
@@ -53,7 +101,7 @@ const Gesture = withGesture(
         render() {
             return this.props.children(this.props)
         }
-    },
+    }
 )
 
 export { withGesture, Gesture }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@ import React from 'react'
 
 const withGesture = Wrapped =>
     class extends React.Component {
+        static defaultProps = {
+            touch: true,
+            mouse: true
+        }
+
         state = {
             x: 0,
             y: 0,
@@ -16,6 +21,7 @@ const withGesture = Wrapped =>
 
         // Touch handlers
         handleTouchStart = e => {
+            if (!this.props.touch) return
             window.addEventListener('touchmove', this.handleTouchMove)
             window.addEventListener('touchend', this.handleTouchEnd)
             this.handleDown(e.touches[0])
@@ -31,6 +37,7 @@ const withGesture = Wrapped =>
 
         // Mouse handlers
         handleMouseDown = e => {
+            if (!this.props.mouse) return
             window.addEventListener('mousemove', this.handleMouseMoveRaf)
             window.addEventListener('mouseup', this.handleMouseUp)
             this.handleDown(e)

--- a/test/typescript/Gesture.tsx
+++ b/test/typescript/Gesture.tsx
@@ -27,6 +27,8 @@ const allProps = (
         onDown={handleEvent}
         onMove={handleEvent}
         onUp={handleEvent}
+        touch={false}
+        mouse={true}
     >
         {({
             x,

--- a/test/typescript/Gesture.tsx
+++ b/test/typescript/Gesture.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { Gesture, GestureState } from '../../index';
+
+const requiredProps = (
+    <Gesture>{() => null}</Gesture>
+);
+
+const handleEvent = (gestureState: GestureState) => {
+    const {
+        x,
+        y,
+        xDelta,
+        yDelta,
+        xInitial,
+        yInitial,
+        xPrev,
+        yPrev,
+        down,
+        xVelocity,
+        yVelocity,
+    } = gestureState;
+    return gestureState;
+};
+
+const allProps = (
+    <Gesture
+        onDown={handleEvent}
+        onMove={handleEvent}
+        onUp={handleEvent}
+    >
+        {({
+            x,
+            y,
+            xDelta,
+            yDelta,
+            xInitial,
+            yInitial,
+            xPrev,
+            yPrev,
+            down,
+            xVelocity,
+            yVelocity,
+        }) => (
+            <div/>
+        )}
+    </Gesture>
+);
+
+const incorrectHandleEvent = (gestureState: GestureState) => {
+};
+const incorrectEventProp = (
+    <Gesture
+        // typings:expect-error
+        onUp={incorrectHandleEvent}
+    >
+        {() => null}
+    </Gesture>
+);

--- a/test/typescript/Gesture.tsx
+++ b/test/typescript/Gesture.tsx
@@ -46,8 +46,7 @@ const allProps = (
     </Gesture>
 );
 
-const incorrectHandleEvent = (gestureState: GestureState) => {
-};
+const incorrectHandleEvent = (gestureState: GestureState) => {};
 const incorrectEventProp = (
     <Gesture
         // typings:expect-error

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "strict": true
+  }
+}

--- a/test/typescript/withGesture.tsx
+++ b/test/typescript/withGesture.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Gesture, GestureState, withGesture } from '../../index';
+
+interface ChildProps {
+    testProp: boolean;
+}
+
+class ChildComponent extends React.Component<ChildProps> {}
+
+const WrappedComponent = withGesture(
+    ChildComponent,
+);
+
+const wrappedComponent = <WrappedComponent testProp/>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,6 +607,19 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@types/prop-types@*":
+  version "15.5.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.4.9":
+  version "16.4.9"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.9.tgz#98b4dba5a0419dbd594f5dbbb2479e1e153431bb"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -840,6 +853,10 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
+csstype@^2.2.0:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
 
 debug@^2.6.8:
   version "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,6 +838,10 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+commander@^2.12.2:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1582,6 +1586,16 @@ to-fast-properties@^2.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+
+typings-tester@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/typings-tester/-/typings-tester-0.3.1.tgz#53bb9784b0ebd7b93192e6fcd908f14501af3878"
+  dependencies:
+    commander "^2.12.2"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
With this PR developers can choose to disable specific events (touch / mouse) by specifying a prop. For example, the following code will only trigger on touch gestures:

```jsx
<Gesture mouse={false}>
    ...
</Gesture>
```


---

Please note that this PR also includes my Typescript typings from #6