### PR TITLE
fixes Cannot read property 'onAction' of undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const initialState = {
   down: false,
 }
 
-function handlers(set, props) {
+function handlers(set, props = {}) {
   // Common handlers
   const handleUp = () =>
     set(state => {


### PR DESCRIPTION
Hey there,

`props` will be undefined if `useGesture()` is called without arguments, which will cause any code inside `handlers` to choke on accessing any property on `props`

[codesandbox repro here](https://codesandbox.io/s/rrrpz8r104)