### PR TITLE
Conditionally bind touch and mouse events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,8 @@ function handlers(set, props = {}) {
     handleUp()
   }
   return {
-    onMouseDown: handleMouseDown,
-    onTouchStart: handleTouchStart,
+    onMouseDown: props.mouse ? handleMouseDown : undefined,
+    onTouchStart: props.touch ? handleTouchStart : undefined,
   }
 }
 


### PR DESCRIPTION
I saw you've added default values for `touch` and `mouse` props but didn't actually use them. This PR conditionally binds events inside `handlers()` based on the value of those props.

I needed this for a carousel which should be draggable with a mouse, while on touch devices it just uses native horizontal scroll behaviour. With this change I can now do `<Gesture touch={false}>` and have touch events disabled.