### PR TITLE
Support on___Capture

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,10 +125,18 @@ function handlers(set, props = {}, args) {
     handleUp(e)
   }
 
-  return {
-    onMouseDown: props.mouse ? onDown : undefined,
-    onTouchStart: props.touch ? onDown : undefined,
+  const output = {}
+  const capture = props.passive.capture ? 'Capture' : ''
+
+  if (props.mouse) {
+    output[`onMouseDown${capture}`] = onDown
   }
+
+  if (props.touch) {
+    output[`onTouchStart${capture}`] = onDown
+  }
+
+  return output
 }
 
 class Gesture extends React.Component {


### PR DESCRIPTION
From the [react docs](https://reactjs.org/docs/events.html#supported-events):

> The event handlers are triggered by an event in the bubbling phase. To register an event handler for the capture phase, append Capture to the event name; for example, instead of using onClick, you would use onClickCapture to handle the click event in the capture phase.

Unfortunately there is no way to handle `passive` like that (https://github.com/facebook/react/issues/6436).