### PR TITLE
Improving withGesture type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+// Helper type, taken from: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 export type vector2 = [number, number];
 
 export interface GestureState {
@@ -38,11 +41,9 @@ export interface GestureProps {
     children(props: GestureState): React.ReactNode;
 }
 
-type GestureChildComponent<T> = React.ComponentType<T & Partial<GestureState>>;
-
 export function withGesture(config: GestureOptions)
-    : <T>(WrappedComponent: GestureChildComponent<T>)
-    => React.ComponentType<T>
+    : <P extends GestureState>(WrappedComponent: React.ComponentType<P>) 
+    => React.ComponentType<Omit<P, keyof GestureState>>
 
 type GestureEvents = {
     onMouseDown?: React.MouseEventHandler;

--- a/test/typescript/withGesture.tsx
+++ b/test/typescript/withGesture.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {GestureState, withGesture} from '../../index';
 
-interface ChildProps extends Partial<GestureState> {
+interface ChildProps extends GestureState {
     testProp: boolean;
 }
 


### PR DESCRIPTION
This PR changes the way the typing works for the withGesture HOC.

In the current implementation, using the HOC requires you to add the props that will be injected by it to be added to the props type as either optional `readonly target?: HTMLElement` or by extending it from 
partial GestureState `interface ChildProps extends Partial<GestureState>`. 

The problems with this is that it makes those props optional, so if the component is ever used in another context, the compiler won't be able to tell that they are missing.

My proposed implementation makes sure that those props are removed from the resulting component that is returned by the HOC, making it viable to make the props either extend from GestureState or just include any of the GestureState properties. The result can be seen on `test/typescript/withGesture.tsx` and it now compiles, compared to before where if you removed `Partial<>` it would start complaining that all the props from GestureState were missing even from the result from HOC, which defeats the purpose.

This is the same technique used on the react-router typings for withRouter. (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts#L137)