### PR TITLE
Specify correct license (MIT) in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "touch"
     ],
     "author": "Paul Henschel",
-    "license": "ISC",
+    "license": "MIT",
     "bugs": {
         "url": "https://github.com/drcmda/react-with-gesture/issues"
     },


### PR DESCRIPTION
The `LICENSE` file in this repository contains an MIT license but the package is listed as having an ISC license on npm.